### PR TITLE
Added shortcodes for rows and cols, documentation for all shortcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ __________
 
 We’ve built in some shortcodes so you can easily add UI elements found in Bootstrap.
 
+| Shortcode                           |  Arguments                        | Bootstrap Component |
+| -------------                       | -------------                     | ------------- |
+| [button]                            |  type, size, url, text            | http://getbootstrap.com/css/#buttons |
+| [alert]...[/alert]                  |  type, close, text                | http://getbootstrap.com/components/#alerts-dismissible |
+| [block-message]...[/block-message]  | type, close, text                 | http://getbootstrap.com/components/#alerts |
+| [blockquote]...[/blockquote]        | float, cite                       | http://getbootstrap.com/css/#type-blockquotes |
+| [row]...[/row]                      | id                                | http://getbootstrap.com/css/#grid-example-basic
+| [col]...[/col]                      | id, size, span                    | http://getbootstrap.com/css/#grid-example-basic
+
+
+
 Sidebars
 ________
 

--- a/library/shortcodes.php
+++ b/library/shortcodes.php
@@ -103,6 +103,33 @@ function blockquotes( $atts, $content = null ) {
 add_shortcode('blockquote', 'blockquotes'); 
  
 
+function rows($atts, $content = null) {
+    extract( shortcode_atts( array(
+        'id'    => ''
+    ), $atts));
+    return "<div id='" . $id . "' class='row'>" . do_shortcode($content) . "</div>";
+}
+add_shortcode('row', 'rows');
 
+function cols($atts, $content = null) {
+    extract( shortcode_atts( array(
+        'id'    => '',
+        'size' => 'md', /* xs, sm, md, lg */
+        'span' => '6' /* 1-12 */
+    ), $atts ));
+
+    if($span > 12 || $span < 1) {
+        $span = 6;
+    }
+    if(!preg_match('/xs|sm|md|lg/', $size)) {
+        $size = "md";
+    }
+
+    $output = "<div id='" . $id . "' class='col-" . $size . "-" . $span . "'>";
+    $output .= $content;
+    $output .= "</div>";
+    return $output;
+}
+add_shortcode('col', 'cols');
 
 ?>


### PR DESCRIPTION
Added in a couple of shortcodes for rows and cols so that editors will be able to put in their own grids within a post of any size.